### PR TITLE
Support for JSON object logging

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,16 @@
 // @ts-expect-error type properly created in prod
-import type { PrismaClient } from '@prisma/client';
-import Transport, { type TransportStreamOptions } from 'winston-transport';
+import type { PrismaClient } from "@prisma/client";
+import Transport, { type TransportStreamOptions } from "winston-transport";
 
 export interface PrismaTransporterOptions extends TransportStreamOptions {
-    prisma: PrismaClient;
-    tableName?: string;
+  prisma: PrismaClient;
+  tableName?: string;
 }
 
 export interface ILogInfo {
-    level: string;
-    message: string;
-    meta?: Record<string, unknown>;
+  level: string;
+  message: string;
+  meta?: Record<string, unknown>;
 }
 
 /**
@@ -19,69 +19,74 @@ export interface ILogInfo {
  * @param {String} options.prisma Prisma client
  * @param {String} **Optional** options.tableName Name of the table to log to
  * @param {Function} **Optional** options.log Custom log function
- *
+ * 
  * @returns {Object} Winston transport
- *
+ * 
  * Create Primsa Transport plugin for Winston
  */
 export class PrismaWinstonTransporter extends Transport {
-    private prisma: PrismaClient;
-    private tableName: string;
+  private prisma: PrismaClient;
+  private tableName: string;
 
-    constructor(options: PrismaTransporterOptions) {
-        super(options);
+  constructor(options: PrismaTransporterOptions) {
+    super(options);
 
-        this.prisma = options.prisma;
-        this.tableName = options.tableName ?? 'userLog';
-    }
+    this.prisma = options.prisma;
+    this.tableName = options.tableName ?? "userLog";
+  }
 
-    /**
-     * function log (info, callback)
-     * {level, msg, meta} = info
-     * @level {string} Level at which to log the message.
-     * @msg {string} Message to log
-     * @meta {Object} **Optional** Additional metadata to attach
-     * @callback {function} Continuation to respond to when complete.
-     *
-     * @returns {undefined}
-     *
-     * Core logging method exposed to Winston. Metadata is optional.
-     */
-    log(info: ILogInfo, callback?: (error?: Error, value?: unknown) => void): void {
-        // get log content
-        const { level, message, meta } = info;
-        const preparedMessage = message && typeof message === 'object' ? JSON.stringify(message) : message;
+  /**
+   * function log (info, callback)
+   * {level, msg, meta} = info
+   * @level {string} Level at which to log the message.
+   * @msg {string} Message to log
+   * @meta {Object} **Optional** Additional metadata to attach
+   * @callback {function} Continuation to respond to when complete.
+   * 
+   * @returns {undefined}
+   * 
+   * Core logging method exposed to Winston. Metadata is optional.
+   */
+  log(
+    info: ILogInfo,
+    callback?: (error?: Error, value?: unknown) => void
+  ): void {
 
-        process.nextTick(() => {
-            // protect
-            if (!callback) {
-                // eslint-disable-next-line @typescript-eslint/no-empty-function
-                callback = () => {};
-            }
+    // get log content
+    const { level, message, meta } = info;
+    const preparedMessage = message && typeof message === 'object' ? JSON.stringify(message) : message;
 
-            this.prisma[this.tableName]
-                .create({
-                    data: {
-                        level,
-                        message: preparedMessage,
-                        timestamp: new Date(),
-                        meta,
-                    },
-                })
-                .then(() => {
-                    setImmediate(() => {
-                        this.emit('logged', info);
-                    });
 
-                    return callback && callback(undefined, true);
-                })
-                .catch((err: Error) => {
-                    setImmediate(() => {
-                        this.emit('error', err);
-                    });
+    process.nextTick(() => {
+      // protect
+      if (!callback) {
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        callback = () => {};
+      }
 
-                    return callback && callback(err, null);
-                });
+      this.prisma[this.tableName]
+        .create({
+          data: {
+            level,
+            message: preparedMessage,
+            timestamp: new Date(),
+            meta,
+          },
+        })
+        .then(() => {
+          setImmediate(() => {
+            this.emit("logged", info);
+          });
+
+          return callback && callback(undefined, true);
+        })
+        .catch((err: Error) => {
+          setImmediate(() => {
+            this.emit("error", err);
+          });
+
+          return callback && callback(err, null);
         });
-    }
+    });
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,17 @@
 // @ts-expect-error type properly created in prod
-import type { PrismaClient } from "@prisma/client";
-import Transport, { type TransportStreamOptions } from "winston-transport";
+import type { PrismaClient } from '@prisma/client';
+import Transport, { type TransportStreamOptions } from 'winston-transport';
 
 export interface PrismaTransporterOptions extends TransportStreamOptions {
-  prisma: PrismaClient;
-  tableName?: string;
+    prisma: PrismaClient;
+    tableName?: string;
 }
 
 export interface ILogInfo {
-  level: string;
-  message: string;
-  meta?: Record<string, unknown>;
+    level: string;
+    message: string;
+    stack?: Record<string, unknown>;
+    meta?: Record<string, unknown>;
 }
 
 /**
@@ -19,74 +20,70 @@ export interface ILogInfo {
  * @param {String} options.prisma Prisma client
  * @param {String} **Optional** options.tableName Name of the table to log to
  * @param {Function} **Optional** options.log Custom log function
- * 
+ *
  * @returns {Object} Winston transport
- * 
+ *
  * Create Primsa Transport plugin for Winston
  */
 export class PrismaWinstonTransporter extends Transport {
-  private prisma: PrismaClient;
-  private tableName: string;
+    private prisma: PrismaClient;
+    private tableName: string;
 
-  constructor(options: PrismaTransporterOptions) {
-    super(options);
+    constructor(options: PrismaTransporterOptions) {
+        super(options);
 
-    this.prisma = options.prisma;
-    this.tableName = options.tableName ?? "userLog";
-  }
+        this.prisma = options.prisma;
+        this.tableName = options.tableName ?? 'userLog';
+    }
 
-  /**
-   * function log (info, callback)
-   * {level, msg, meta} = info
-   * @level {string} Level at which to log the message.
-   * @msg {string} Message to log
-   * @meta {Object} **Optional** Additional metadata to attach
-   * @callback {function} Continuation to respond to when complete.
-   * 
-   * @returns {undefined}
-   * 
-   * Core logging method exposed to Winston. Metadata is optional.
-   */
-  log(
-    info: ILogInfo,
-    callback?: (error?: Error, value?: unknown) => void
-  ): void {
+    /**
+     * function log (info, callback)
+     * {level, msg, meta} = info
+     * @level {string} Level at which to log the message.
+     * @msg {string} Message to log
+     * @meta {Object} **Optional** Additional metadata to attach
+     * @callback {function} Continuation to respond to when complete.
+     *
+     * @returns {undefined}
+     *
+     * Core logging method exposed to Winston. Metadata is optional.
+     */
+    log(info: ILogInfo, callback?: (error?: Error, value?: unknown) => void): void {
+        // get log content
+        const { level, message, stack, meta } = info;
+        const preparedMessage = message && typeof message === 'object' ? JSON.stringify(message) : message;
 
-    // get log content
-    const { level, message, meta } = info;
-    const preparedMessage = message && typeof message === 'object' ? JSON.stringify(message) : message;
+        process.nextTick(() => {
+            // protect
+            if (!callback) {
+                // eslint-disable-next-line @typescript-eslint/no-empty-function
+                callback = () => {};
+            }
 
+            this.prisma[this.tableName]
+                .create({
+                    data: {
+                        level,
+                        message: preparedMessage,
+                        timestamp: new Date(),
+                        stack,
+                        meta,
+                    },
+                })
+                .then(() => {
+                    setImmediate(() => {
+                        this.emit('logged', info);
+                    });
 
-    process.nextTick(() => {
-      // protect
-      if (!callback) {
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
-        callback = () => {};
-      }
+                    return callback && callback(undefined, true);
+                })
+                .catch((err: Error) => {
+                    setImmediate(() => {
+                        this.emit('error', err);
+                    });
 
-      this.prisma[this.tableName]
-        .create({
-          data: {
-            level,
-            message: preparedMessage,
-            timestamp: new Date(),
-            meta,
-          },
-        })
-        .then(() => {
-          setImmediate(() => {
-            this.emit("logged", info);
-          });
-
-          return callback && callback(undefined, true);
-        })
-        .catch((err: Error) => {
-          setImmediate(() => {
-            this.emit("error", err);
-          });
-
-          return callback && callback(err, null);
+                    return callback && callback(err, null);
+                });
         });
-    });
-  }
+    }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,16 @@
 // @ts-expect-error type properly created in prod
-import type { PrismaClient } from "@prisma/client";
-import Transport, { type TransportStreamOptions } from "winston-transport";
+import type { PrismaClient } from '@prisma/client';
+import Transport, { type TransportStreamOptions } from 'winston-transport';
 
 export interface PrismaTransporterOptions extends TransportStreamOptions {
-  prisma: PrismaClient;
-  tableName?: string;
+    prisma: PrismaClient;
+    tableName?: string;
 }
 
 export interface ILogInfo {
-  level: string;
-  message: string;
-  meta?: Record<string, unknown>;
+    level: string;
+    message: string;
+    meta?: Record<string, unknown>;
 }
 
 /**
@@ -19,72 +19,69 @@ export interface ILogInfo {
  * @param {String} options.prisma Prisma client
  * @param {String} **Optional** options.tableName Name of the table to log to
  * @param {Function} **Optional** options.log Custom log function
- * 
+ *
  * @returns {Object} Winston transport
- * 
+ *
  * Create Primsa Transport plugin for Winston
  */
 export class PrismaWinstonTransporter extends Transport {
-  private prisma: PrismaClient;
-  private tableName: string;
+    private prisma: PrismaClient;
+    private tableName: string;
 
-  constructor(options: PrismaTransporterOptions) {
-    super(options);
+    constructor(options: PrismaTransporterOptions) {
+        super(options);
 
-    this.prisma = options.prisma;
-    this.tableName = options.tableName ?? "userLog";
-  }
+        this.prisma = options.prisma;
+        this.tableName = options.tableName ?? 'userLog';
+    }
 
-  /**
-   * function log (info, callback)
-   * {level, msg, meta} = info
-   * @level {string} Level at which to log the message.
-   * @msg {string} Message to log
-   * @meta {Object} **Optional** Additional metadata to attach
-   * @callback {function} Continuation to respond to when complete.
-   * 
-   * @returns {undefined}
-   * 
-   * Core logging method exposed to Winston. Metadata is optional.
-   */
-  log(
-    info: ILogInfo,
-    callback?: (error?: Error, value?: unknown) => void
-  ): void {
+    /**
+     * function log (info, callback)
+     * {level, msg, meta} = info
+     * @level {string} Level at which to log the message.
+     * @msg {string} Message to log
+     * @meta {Object} **Optional** Additional metadata to attach
+     * @callback {function} Continuation to respond to when complete.
+     *
+     * @returns {undefined}
+     *
+     * Core logging method exposed to Winston. Metadata is optional.
+     */
+    log(info: ILogInfo, callback?: (error?: Error, value?: unknown) => void): void {
+        // get log content
+        const { level, message, meta } = info;
+        const preparedMessage = message && typeof message === 'object' ? JSON.stringify(message) : message;
 
-    // get log content
-    const { level, message, meta } = info;
+        process.nextTick(() => {
+            // protect
+            if (!callback) {
+                // eslint-disable-next-line @typescript-eslint/no-empty-function
+                callback = () => {};
+            }
 
-    process.nextTick(() => {
-      // protect
-      if (!callback) {
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
-        callback = () => {};
-      }
+            this.prisma[this.tableName]
+                .create({
+                    data: {
+                        level,
+                        message: preparedMessage,
+                        timestamp: new Date(),
+                        meta,
+                    },
+                })
+                .then(() => {
+                    setImmediate(() => {
+                        this.emit('logged', info);
+                    });
 
-      this.prisma[this.tableName]
-        .create({
-          data: {
-            level,
-            message,
-            timestamp: new Date(),
-            meta,
-          },
-        })
-        .then(() => {
-          setImmediate(() => {
-            this.emit("logged", info);
-          });
+                    return callback && callback(undefined, true);
+                })
+                .catch((err: Error) => {
+                    setImmediate(() => {
+                        this.emit('error', err);
+                    });
 
-          return callback && callback(undefined, true);
-        })
-        .catch((err: Error) => {
-          setImmediate(() => {
-            this.emit("error", err);
-          });
-
-          return callback && callback(err, null);
+                    return callback && callback(err, null);
+                });
         });
-    });
-  }
+    }
 }


### PR DESCRIPTION
Now, when trying to pass an object to the logger, Prisma throws an exception: 
`on prisma.create One Log. Provided Json, expected String.` 
This patch solves this problem. Now the objects pass through JSON.stringify() and get into the database as a string.